### PR TITLE
Add basic risk engine for bank statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # Projects
+
 Just for fun
+
+## Risk Engine Example
+
+This repository includes a simple Python script that analyzes a bank statement CSV file and prints basic risk signals. To try it out:
+
+1. Ensure you have Python 3 installed (no external packages are required).
+2. Run the script against `sample_bank_statement.csv`:
+
+```bash
+python3 risk_engine.py sample_bank_statement.csv
+```
+
+You can replace `sample_bank_statement.csv` with your own statement file in the same format (columns: `Date`, `Description`, `Amount`, `Balance`).
+
+## Web UI
+
+You can also try the risk engine in your browser using a small Flask app. First install Flask:
+
+```bash
+pip install flask
+```
+
+Run the web application:
+
+```bash
+python3 app.py
+```
+
+Then open <http://localhost:5000> and upload a CSV bank statement. The detected risk signals will be highlighted on the page.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,28 @@
+from flask import Flask, render_template, request
+from werkzeug.utils import secure_filename
+import os
+from risk_engine import parse_transactions, analyze
+
+app = Flask(__name__)
+app.config['UPLOAD_FOLDER'] = 'uploads'
+
+os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    signals = None
+    if request.method == 'POST':
+        if 'statement' not in request.files:
+            return render_template('index.html', error='No file part')
+        file = request.files['statement']
+        if file.filename == '':
+            return render_template('index.html', error='No selected file')
+        filename = secure_filename(file.filename)
+        path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+        file.save(path)
+        transactions = parse_transactions(path)
+        signals = analyze(transactions)
+    return render_template('index.html', signals=signals)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/risk_engine.py
+++ b/risk_engine.py
@@ -1,0 +1,74 @@
+import csv
+import sys
+
+LARGE_TRANSACTION_THRESHOLD = 1000.0
+
+
+def parse_transactions(path):
+    """Load transactions from a CSV file."""
+    transactions = []
+    with open(path, newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            try:
+                amount = float(row.get("Amount", 0))
+            except ValueError:
+                continue
+            try:
+                balance = float(row.get("Balance", 0))
+            except ValueError:
+                balance = 0
+            transactions.append({
+                "date": row.get("Date"),
+                "description": row.get("Description", ""),
+                "amount": amount,
+                "balance": balance,
+            })
+    return transactions
+
+
+def analyze(transactions):
+    risk_signals = []
+
+    # Negative balance days
+    negative_days = [t for t in transactions if t["balance"] < 0]
+    if negative_days:
+        risk_signals.append(
+            f"Account had negative balance on {len(negative_days)} days"
+        )
+
+    # Large transactions
+    large = [t for t in transactions if abs(t["amount"]) >= LARGE_TRANSACTION_THRESHOLD]
+    for t in large:
+        risk_signals.append(
+            f"Large transaction {t['amount']:.2f} on {t['date']} ({t['description']})"
+        )
+
+    # Count cash/ATM withdrawals
+    atm = [t for t in transactions if "ATM" in t["description"].upper() or "CASH" in t["description"].upper()]
+    if atm:
+        risk_signals.append(f"ATM/cash withdrawals: {len(atm)}")
+
+    # Withdrawal to deposit ratio
+    deposits = sum(t["amount"] for t in transactions if t["amount"] > 0)
+    withdrawals = -sum(t["amount"] for t in transactions if t["amount"] < 0)
+    if deposits:
+        ratio = withdrawals / deposits
+        risk_signals.append(f"Withdrawal to deposit ratio: {ratio:.2f}")
+
+    return risk_signals
+
+
+def main(path):
+    transactions = parse_transactions(path)
+    signals = analyze(transactions)
+    print("Risk signals:")
+    for s in signals:
+        print("-", s)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python3 risk_engine.py <statement.csv>")
+        sys.exit(1)
+    main(sys.argv[1])

--- a/sample_bank_statement.csv
+++ b/sample_bank_statement.csv
@@ -1,0 +1,11 @@
+Date,Description,Amount,Balance
+2024-06-01,Salary,3000,3000
+2024-06-02,Groceries,-100,2900
+2024-06-03,ATM Withdrawal,-200,2700
+2024-06-04,Car Payment,-400,2300
+2024-06-10,Rent,-1500,800
+2024-06-15,Online Purchase,-500,300
+2024-06-20,Rent,-1500,-1200
+2024-06-21,Bank Fee,-50,-1250
+2024-06-28,Salary,3000,1750
+2024-06-29,Vacation,-2000,-250

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Risk Engine Upload</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        .signals { margin-top: 1em; }
+        .signal { background: #ffdddd; border-left: 4px solid #f44336; padding: 8px; margin-bottom: 5px; }
+    </style>
+</head>
+<body>
+    <h1>Upload Bank Statement</h1>
+    <form method="post" enctype="multipart/form-data">
+        <input type="file" name="statement" accept=".csv" required>
+        <button type="submit">Analyze</button>
+    </form>
+    {% if signals is not none %}
+    <div class="signals">
+        <h2>Risk Signals</h2>
+        {% if signals %}
+            {% for s in signals %}
+                <div class="signal">{{ s }}</div>
+            {% endfor %}
+        {% else %}
+            <p>No risk signals detected.</p>
+        {% endif %}
+    </div>
+    {% endif %}
+    {% if error %}
+        <p style="color:red">{{ error }}</p>
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple Python script `risk_engine.py` that parses CSV bank statements
- include a `sample_bank_statement.csv` for testing
- update README with instructions on running the risk engine
- add a simple Flask UI to upload a CSV and display highlighted risk signals

## Testing
- `python3 risk_engine.py sample_bank_statement.csv`
- `python3 -m py_compile risk_engine.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68582b9a1eb483239f06434ba3867cbf